### PR TITLE
Update: Minor changes on MainServices

### DIFF
--- a/src/components/CommonStyles.js
+++ b/src/components/CommonStyles.js
@@ -1,6 +1,12 @@
 import { Box, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
 
+const FlexRowCenter = styled(Box)({
+  width: "100%",
+  display: "flex",
+  justifyContent: "center",
+});
+
 const MediumContainer = styled(Box)({
   maxWidth: "900px",
 });
@@ -9,11 +15,10 @@ const LargeContainer = styled(Box)({
   maxWidth: "1200px",
 });
 
-const HighlightSecondary = styled("span")(({ theme }) => ({
+const HighlightRed = styled("span")(({ theme }) => ({
   color: theme.palette.error.main,
   fontWeight: 600,
   textDecoration: "underline",
-  paddingLeft: "8px",
 }));
 
 const DividerContainer = styled(Box)({
@@ -74,4 +79,10 @@ const Divider = () => (
   </DividerContainer>
 );
 
-export { MediumContainer, LargeContainer, HighlightSecondary, Divider };
+export {
+  FlexRowCenter,
+  MediumContainer,
+  LargeContainer,
+  HighlightRed,
+  Divider,
+};

--- a/src/components/MainServices.js
+++ b/src/components/MainServices.js
@@ -9,8 +9,6 @@ import toothbrush from "stories/assets/toothbrush.png";
 import bed from "stories/assets/bed.png";
 import ambulance from "stories/assets/ambulance.png";
 
-import PropTypes from "prop-types";
-
 const Container = styled(LargeContainer)({
   display: "flex",
   alignItems: "flex-start",
@@ -74,17 +72,7 @@ const Description = styled(Typography)(({ theme }) =>
   mergician(getCommonStyles({ theme }), { marginBottom: "0px" })
 );
 
-const MainServices = ({ linksList }) => {
-  const links = linksList.map((item, index) => (
-    <PageLink
-      to={item.to}
-      key={item.label}
-      sx={{ marginRight: index === 0 ? "32px" : "0px" }}
-    >
-      {item.label}
-    </PageLink>
-  ));
-
+const MainServices = () => {
   return (
     <Container>
       <ServicesListContainer>
@@ -124,27 +112,19 @@ const MainServices = ({ linksList }) => {
           </HighlightRed>
         </InfoContainer>
       </ServicesListContainer>
-      <FlexRowCenter>{links}</FlexRowCenter>
+      <FlexRowCenter>
+        <PageLink
+          to='/?path=/story/stories-mainservices--playground'
+          sx={{ marginRight: "32px" }}
+        >
+          Ver todo
+        </PageLink>
+        <PageLink to='/?path=/story/stories-mainservices--playground'>
+          Solicitar turno
+        </PageLink>
+      </FlexRowCenter>
     </Container>
   );
-};
-
-MainServices.prototype = {
-  linksList: PropTypes.arrayOf(
-    PropTypes.shape({
-      label: PropTypes.string,
-      to: PropTypes.string,
-    })
-  ).isRequired,
-};
-
-MainServices.defaultProps = {
-  linksList: [
-    {
-      label: "",
-      to: "",
-    },
-  ],
 };
 
 export default MainServices;

--- a/src/components/MainServices.js
+++ b/src/components/MainServices.js
@@ -1,6 +1,6 @@
 import PageLink from "components/PageLink";
-import { LargeContainer } from "components/CommonStyles";
-import { HighlightSecondary } from "components/CommonStyles";
+import { LargeContainer, FlexRowCenter } from "components/CommonStyles";
+import { HighlightRed } from "components/CommonStyles";
 import { Box, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import mergician from "mergician";
@@ -15,12 +15,6 @@ const Container = styled(LargeContainer)({
   display: "flex",
   alignItems: "flex-start",
   flexWrap: "wrap",
-});
-
-const LinksContainer = styled(Box)({
-  width: "100%",
-  display: "flex",
-  justifyContent: "center",
 });
 
 const ServicesListContainer = styled(Box)(({ theme }) => ({
@@ -81,13 +75,14 @@ const Description = styled(Typography)(({ theme }) =>
 );
 
 const MainServices = ({ linksList }) => {
-  const links = linksList.map((item) => (
+  const links = linksList.map((item, index) => (
     <PageLink
-      label={item.label}
       to={item.to}
       key={item.label}
-      sx={{ marginLeft: "8px", marginRight: "8px" }}
-    />
+      sx={{ marginRight: index === 0 ? "32px" : "0px" }}
+    >
+      {item.label}
+    </PageLink>
   ));
 
   return (
@@ -123,13 +118,13 @@ const MainServices = ({ linksList }) => {
           <Description>
             Atendemos tu emergencia las 24/7: estamos aquí para proteger la
             salud de tu mascota.
-          </Description>
-          <HighlightSecondary sx={{ fontSize: "1.5rem", textAlign: "center" }}>
+          </Description>{" "}
+          <HighlightRed sx={{ fontSize: "1.5rem", textAlign: "center" }}>
             Te: 555-555-555
-          </HighlightSecondary>
+          </HighlightRed>
         </InfoContainer>
       </ServicesListContainer>
-      <LinksContainer>{links}</LinksContainer>
+      <FlexRowCenter>{links}</FlexRowCenter>
     </Container>
   );
 };

--- a/src/components/PageLink.js
+++ b/src/components/PageLink.js
@@ -33,9 +33,9 @@ const StyledPageLink = styled(Link)(({ theme }) => ({
   },
 }));
 
-const PageLink = ({ to, label, ...props }) => (
+const PageLink = ({ to, children, ...props }) => (
   <StyledPageLink to={to} {...props}>
-    <Typography variant='button'>{label}</Typography>
+    <Typography variant='button'>{children}</Typography>
   </StyledPageLink>
 );
 

--- a/src/stories/MainServices.stories.js
+++ b/src/stories/MainServices.stories.js
@@ -6,22 +6,9 @@ import { Box } from "@mui/material";
 
 export default {
   component: MainServices,
-  argTypes: {
-    linksList: {
-      defaultValue: [
-        {
-          label: "",
-          to: "",
-        },
-      ],
-      control: { type: "object" },
-      description:
-        "Array of objects with props for React-Router's Link components",
-    },
-  },
 };
 
-export const Playground = (args) => (
+export const Playground = () => (
   <Box
     sx={{
       minWidth: "360px",
@@ -34,19 +21,6 @@ export const Playground = (args) => (
   >
     <Divider.Template />
     <ProminentTitle.Template />
-    <MainServices {...args} />
+    <MainServices />
   </Box>
 );
-
-Playground.args = {
-  linksList: [
-    {
-      label: "Ver todo",
-      to: "/?path=/story/stories-mainservices--playground",
-    },
-    {
-      label: "Solicitar turno",
-      to: "/?path=/story/stories-mainservices--playground",
-    },
-  ],
-};

--- a/src/stories/MainServices.stories.js
+++ b/src/stories/MainServices.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import MainServices from "components/MainServices";
-import * as FeaturedTitle from "stories/FeaturedTitle.stories";
+import * as ProminentTitle from "stories/ProminentTitle.stories";
 import * as Divider from "stories/Divider.stories";
 import { Box } from "@mui/material";
 
@@ -33,7 +33,7 @@ export const Playground = (args) => (
     }}
   >
     <Divider.Template />
-    <FeaturedTitle.Template />
+    <ProminentTitle.Template />
     <MainServices {...args} />
   </Box>
 );


### PR DESCRIPTION
# Previous

- The MainServices file hold outdated component names and a component "LinksContainer" that can be reusable.
- The MainServices component uses a linksList to render PageLink components

# After update

- The LinksContainer component will be extracted to CommonStyles.js and renamed to FlexRowCenter.
- The outdated component names will be updated.
- The linksList prop will be removed.