### PR TITLE
HotFix: Add "if" block to avoid error:

### DIFF
--- a/src/hooks/useTriggerOnScroll.js
+++ b/src/hooks/useTriggerOnScroll.js
@@ -2,21 +2,22 @@ import { useState, useEffect, useRef } from "react";
 
 const useTriggerOnScroll = () => {
   const targetEl = useRef(null);
-
   const [trigger, setTrigger] = useState(false);
 
   const [scrolling, setScrolling] = useState(false);
 
   useEffect(() => {
     const detectElement = () => {
-      const innerHeight =
-        window.innerHeight || document.documentElement.clientHeight;
-      const rect = targetEl.current.getBoundingClientRect();
+      if (targetEl.current !== null) {
+        const innerHeight =
+          window.innerHeight || document.documentElement.clientHeight;
+        const rect = targetEl.current.getBoundingClientRect();
 
-      const reachBottomBorder = rect.bottom <= innerHeight;
+        const reachBottomBorder = rect.bottom <= innerHeight;
 
-      if (reachBottomBorder) {
-        setTrigger(true);
+        if (reachBottomBorder) {
+          setTrigger(true);
+        }
       }
     };
 


### PR DESCRIPTION
#Issue

When the "detectScroll" function is used but not the "detectElement" function thus the ref isn't used neither, the detectElement function is executed and throws a "Cannot read property getBoundingClientRect of null" error.

#Fix

It will be added an "if" block inside the detectElement function to avoid this error case.